### PR TITLE
AVE-1525 - Time-Space Diagrams - X-axis time doesn't reflect input times

### DIFF
--- a/ATSPM/ReportApi/Program.cs
+++ b/ATSPM/ReportApi/Program.cs
@@ -39,6 +39,7 @@ using Microsoft.OpenApi.Models;
 using MOE.Common.Business.WCFServiceLibrary;
 using Moq;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using ATSPM.ReportApi.Utilities;
 
 var builder = WebApplication.CreateBuilder(args);
 AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
@@ -57,7 +58,12 @@ builder.Host.ConfigureServices((h, s) =>
         o.Filters.Add(new ProducesResponseTypeAttribute(StatusCodes.Status406NotAcceptable));
         o.Filters.Add(new ProducesAttribute("application/json", "application/xml"));
     })
-    .AddXmlDataContractSerializerFormatters();
+    .AddXmlDataContractSerializerFormatters()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new CustomDateTimeConverter());
+    });
+
     s.AddProblemDetails();
 
     s.AddResponseCompression(o =>

--- a/ATSPM/ReportApi/Utilities/CustomDateTimeConverter.cs
+++ b/ATSPM/ReportApi/Utilities/CustomDateTimeConverter.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ATSPM.ReportApi.Utilities
+{
+    public class CustomDateTimeConverter : JsonConverter<DateTime>
+    {
+        private const string DateFormat = "yyyy-MM-ddTHH:mm:ss";
+
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return DateTime.Parse(reader.GetString());
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString(DateFormat));
+        }
+    }
+}


### PR DESCRIPTION
Adding in a customDateTime Converter so that we can not have the Z time on it.