### PR TITLE
Double resources for cloud run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,8 +86,8 @@ jobs:
               --image ${{ vars.GCP_ARTIFACT_REPO }}/$image:latest \
               --service-account ${{vars.RUN_SA}} \
               --vpc-connector ${{ vars.VPC_CONNECTOR }} \
-              --memory=2Gi \
-              --cpu=1 \
+              --memory=4Gi \
+              --cpu=2 \
               --max-retries 0 \
               --parallelism 0 
           else
@@ -96,8 +96,8 @@ jobs:
               --image ${{ vars.GCP_ARTIFACT_REPO }}/$image:latest \
               --service-account ${{vars.RUN_SA}} \
               --vpc-connector ${{ vars.VPC_CONNECTOR }} \
-              --memory=2Gi \
-              --cpu=1 \
+              --memory=4Gi \
+              --cpu=2 \
               --max-retries 0 \
               --parallelism 0 
           fi;


### PR DESCRIPTION
4 GB memory requires at least 2 cpu, so both stats got doubled.