### PR TITLE
Update exit code handling in HostedServiceBase.cs

### DIFF
--- a/Atspm/Infrastructure/Services/HostedServices/HostedServiceBase.cs
+++ b/Atspm/Infrastructure/Services/HostedServices/HostedServiceBase.cs
@@ -68,11 +68,11 @@ namespace Utah.Udot.Atspm.Infrastructure.Services.HostedServices
                 {
                     await Process(scope, sw, cancellationToken);
 
-                    Environment.ExitCode = 1;
+                    Environment.ExitCode = 0;
                 }
                 catch (Exception)
                 {
-                    Environment.ExitCode = 0;
+                    Environment.ExitCode = 1;
 
                     throw;
                 }


### PR DESCRIPTION
Modify exit codes in try-catch block to reflect success and failure accurately. Set exit code to 0 for successful processing and 1 for exceptions, improving application signal for process outcomes.