### PR TITLE
Add copy-sql resume support and approach speed percentile fix

### DIFF
--- a/Atspm/Application/Business/ApproachSpeed/AvgSpeedBucket.cs
+++ b/Atspm/Application/Business/ApproachSpeed/AvgSpeedBucket.cs
@@ -80,19 +80,23 @@ namespace Utah.Udot.Atspm.Business.ApproachSpeed
             var percentileValue = 0;
             try
             {
+                if (speeds.Count == 1)
+                    return speeds[0];
+
                 var tempPercentileIndex = SpeedVolume * percentile - 1;
                 var percentileIndex = 0;
                 if (SpeedVolume > 3)
                 {
 
                     percentileIndex = Convert.ToInt32(Math.Round(tempPercentileIndex + .5));
-                    percentileValue = speeds[percentileIndex];
+                    percentileValue = speeds[Math.Clamp(percentileIndex, 0, speeds.Count - 1)];
                 }
                 else
                 {
-                    percentileIndex = Convert.ToInt32(tempPercentileIndex);
+                    percentileIndex = Math.Clamp(Convert.ToInt32(tempPercentileIndex), 0, speeds.Count - 1);
+                    var nextPercentileIndex = Math.Clamp(percentileIndex + 1, 0, speeds.Count - 1);
                     var speed1 = (double)speeds[percentileIndex];
-                    var speed2 = (double)speeds[percentileIndex + 1];
+                    var speed2 = (double)speeds[nextPercentileIndex];
                     double rawPercentile = (speed1 + speed2) / 2;
                     percentileValue = Convert.ToInt32(Math.Round(rawPercentile));
                 }

--- a/Atspm/Application/Business/Common/PlanService.cs
+++ b/Atspm/Application/Business/Common/PlanService.cs
@@ -351,19 +351,23 @@ namespace Utah.Udot.Atspm.Business.Common
             if (speeds.IsNullOrEmpty())
                 return null;
             var sortedSpeeds = speeds.OrderBy(x => x).ToList();
+            if (sortedSpeeds.Count == 1)
+                return sortedSpeeds[0];
+
             var tempPercentileIndex = sortedSpeeds.Count * percentile - 1;
             var percentileIndex = 0;
             var percentileValue = 0;
             if (sortedSpeeds.Count > 3)
             {
                 percentileIndex = Convert.ToInt32(Math.Round(tempPercentileIndex + 0.5));
-                percentileValue = sortedSpeeds[percentileIndex];
+                percentileValue = sortedSpeeds[Math.Clamp(percentileIndex, 0, sortedSpeeds.Count - 1)];
             }
             else
             {
-                percentileIndex = Convert.ToInt32(tempPercentileIndex);
-                var speed1 = (double)speeds[percentileIndex];
-                var speed2 = (double)speeds[percentileIndex + 1];
+                percentileIndex = Math.Clamp(Convert.ToInt32(tempPercentileIndex), 0, sortedSpeeds.Count - 1);
+                var nextPercentileIndex = Math.Clamp(percentileIndex + 1, 0, sortedSpeeds.Count - 1);
+                var speed1 = (double)sortedSpeeds[percentileIndex];
+                var speed2 = (double)sortedSpeeds[nextPercentileIndex];
                 double rawPercentile = (speed1 + speed2) / 2;
                 percentileValue = Convert.ToInt32(Math.Round(rawPercentile));
 

--- a/Atspm/ApplicationTests/Business/Common/PlanServiceTests.cs
+++ b/Atspm/ApplicationTests/Business/Common/PlanServiceTests.cs
@@ -158,6 +158,49 @@ namespace Utah.Udot.ATSPM.ApplicationTests.Business.Common
     }
 
 
+    public class PlanServiceSpeedStatisticsTests
+    {
+        private readonly PlanService _planService;
+
+        public PlanServiceSpeedStatisticsTests()
+        {
+            _planService = new PlanService();
+        }
+
+        [Fact]
+        public void SetSpeedStatistics_SingleSpeed_DoesNotThrow()
+        {
+            _planService.SetSpeedStatistics(
+                new List<int> { 37 },
+                out var avgSpeed,
+                out var stdDev,
+                out var eightyFifth,
+                out var fifteenth);
+
+            Assert.Equal(37, avgSpeed);
+            Assert.Equal(0, stdDev);
+            Assert.Equal(37, eightyFifth);
+            Assert.Equal(37, fifteenth);
+        }
+
+        [Fact]
+        public void SetSpeedStatistics_TwoSpeeds_DoesNotThrow()
+        {
+            _planService.SetSpeedStatistics(
+                new List<int> { 30, 40 },
+                out var avgSpeed,
+                out var stdDev,
+                out var eightyFifth,
+                out var fifteenth);
+
+            Assert.Equal(35, avgSpeed);
+            Assert.Equal(5, stdDev);
+            Assert.NotNull(eightyFifth);
+            Assert.NotNull(fifteenth);
+        }
+    }
+
+
 
     public class GetTransitSignalPriorityBasicPlansTests
     {

--- a/Atspm/DatabaseInstaller/Commands/MoveEventLogsSqlServerToPostgresCommand.cs
+++ b/Atspm/DatabaseInstaller/Commands/MoveEventLogsSqlServerToPostgresCommand.cs
@@ -34,6 +34,7 @@ namespace DatabaseInstaller.Commands
             AddOption(LocationsOption);
             AddOption(DeviceOption);
             AddOption(BatchSizeOption);
+            AddOption(ResumeOption);
         }
 
         public Option<string> SourceOption { get; set; } = new("--source", "Connection string for the source SQL Server");
@@ -42,6 +43,7 @@ namespace DatabaseInstaller.Commands
         public Option<string> LocationsOption { get; set; } = new("--locations", "Comma seperated list of location identifiers") { IsRequired = false };
         public Option<int?> DeviceOption { get; set; } = new("--device", "Id of Device Type used to import events for just that device type") { IsRequired = false };
         public Option<int?> BatchSizeOption { get; set; } = new("--batch-size", "Size of insert batches for copy-sql") { IsRequired = false };
+        public Option<bool> ResumeOption { get; set; } = new("--resume", "Skip location-days that already have all source rows in the destination") { IsRequired = false };
 
         public ModelBinder<TransferCommandConfiguration> GetOptionsBinder()
         {
@@ -53,6 +55,7 @@ namespace DatabaseInstaller.Commands
             binder.BindMemberFromValue(b => b.Locations, LocationsOption);
             binder.BindMemberFromValue(b => b.Device, DeviceOption);
             binder.BindMemberFromValue(b => b.CopyBatchSize, BatchSizeOption);
+            binder.BindMemberFromValue(b => b.Resume, ResumeOption);
 
             return binder;
         }

--- a/Atspm/DatabaseInstaller/Commands/TransferEventLogsCommand.cs
+++ b/Atspm/DatabaseInstaller/Commands/TransferEventLogsCommand.cs
@@ -74,6 +74,7 @@ namespace DatabaseInstaller.Commands
         public int? Batch { get; set; }
         public int MaxConcurrency { get; set; } = 2;
         public int CopyBatchSize { get; set; } = 250;
+        public bool Resume { get; set; }
         public string Locations { get; set; }
 
     }

--- a/Atspm/DatabaseInstaller/README.md
+++ b/Atspm/DatabaseInstaller/README.md
@@ -232,6 +232,7 @@ Copies rows from the source SQL Server `CompressedEvents` table into the Postgre
 - `--locations`
 - `--device`
 - `--batch-size`
+- `--resume`
 - `MaxConcurrency` from `TransferCommandConfiguration`
 
 ### Notes
@@ -240,6 +241,7 @@ Copies rows from the source SQL Server `CompressedEvents` table into the Postgre
 - That makes it much faster than rebuilding each hourly record from expanded events.
 - `MaxConcurrency` controls how many locations are processed in parallel. The default is `2`. Start there and increase carefully.
 - `--batch-size` controls how many rows are sent in each insert batch. The default is `250`.
+- `--resume` builds a batched resume plan for the requested locations and date range, then skips location-days where every SQL Server source key already exists in PostgreSQL. Partial days are replayed safely because inserts use `ON CONFLICT DO NOTHING`.
 - Each location worker keeps one SQL Server connection and one PostgreSQL connection open for all of its batches.
 - The command reads `TransferCommandConfiguration:MaxConcurrency` and `TransferCommandConfiguration:CopyBatchSize` from `appsettings.json` or user secrets, so you can tune both without changing the command line.
 - This assumes the source SQL Server database is already using the same `CompressedEvents` schema and payload format as the target PostgreSQL database.
@@ -253,6 +255,7 @@ dotnet run --project DatabaseInstaller -- copy-sql \
   --start "2024-01-01" \
   --end "2024-01-31" \
   --batch-size 500 \
+  --resume \
   --locations "LOC1,LOC2"
 ```
 

--- a/Atspm/DatabaseInstaller/Services/MoveEventLogsSqlServerToPostgresHostedService.cs
+++ b/Atspm/DatabaseInstaller/Services/MoveEventLogsSqlServerToPostgresHostedService.cs
@@ -63,6 +63,14 @@ namespace DatabaseInstaller.Services
             try
             {
                 var locations = GetTargetLocations();
+                var destinationConnectionString = GetDestinationConnectionString();
+                var resumePlan = _config.Resume
+                    ? await BuildResumePlanAsync(
+                        locations.Select(l => l.LocationIdentifier).Distinct().ToList(),
+                        destinationConnectionString,
+                        cancellationToken)
+                    : ResumePlan.Empty;
+
                 var parallelOptions = new ParallelOptions
                 {
                     CancellationToken = cancellationToken,
@@ -71,7 +79,7 @@ namespace DatabaseInstaller.Services
 
                 await Parallel.ForEachAsync(locations, parallelOptions, async (location, token) =>
                 {
-                    await ProcessLocationAsync(location, token);
+                    await ProcessLocationAsync(location, destinationConnectionString, resumePlan, token);
                 });
 
                 _logger.LogInformation("Event logs moved successfully.");
@@ -115,11 +123,22 @@ namespace DatabaseInstaller.Services
                 .ToList();
         }
 
-        private async Task ProcessLocationAsync(Location location, CancellationToken cancellationToken)
+        private async Task ProcessLocationAsync(
+            Location location,
+            string destinationConnectionString,
+            ResumePlan resumePlan,
+            CancellationToken cancellationToken)
         {
             _logger.LogInformation("Processing location {LocationId}", location.LocationIdentifier);
 
-            var destinationConnectionString = GetDestinationConnectionString();
+            var datesToProcess = GetDatesToProcess(location.LocationIdentifier, resumePlan).ToList();
+            if (datesToProcess.Count == 0)
+            {
+                _logger.LogInformation(
+                    "Skipping location {LocationId}; resume plan found no source days missing from the destination.",
+                    location.LocationIdentifier);
+                return;
+            }
 
             await using var sourceConnection = new SqlConnection(_config.Source);
             await sourceConnection.OpenAsync(cancellationToken);
@@ -127,23 +146,68 @@ namespace DatabaseInstaller.Services
             await using var destinationConnection = new NpgsqlConnection(destinationConnectionString);
             await destinationConnection.OpenAsync(cancellationToken);
 
+            foreach (var date in datesToProcess)
+            {
+                await ProcessDateAsync(location, date, resumePlan, sourceConnection, destinationConnection, cancellationToken);
+            }
+        }
+
+        private IEnumerable<DateTime> GetDatesToProcess(string locationIdentifier, ResumePlan resumePlan)
+        {
             for (var date = _config.Start.Date;
                  date <= _config.End.Date;
                  date = date.AddDays(1))
             {
-                await ProcessDateAsync(location, date, sourceConnection, destinationConnection, cancellationToken);
+                if (!_config.Resume || !resumePlan.ShouldSkip(locationIdentifier, date, out _))
+                {
+                    yield return date;
+                }
             }
         }
 
         private async Task ProcessDateAsync(
             Location location,
             DateTime date,
+            ResumePlan resumePlan,
             SqlConnection sourceConnection,
             NpgsqlConnection destinationConnection,
             CancellationToken cancellationToken)
         {
             var dayStart = date.Date;
             var dayEnd = dayStart.AddDays(1);
+
+            if (_config.Resume)
+            {
+                if (resumePlan.ShouldSkip(location.LocationIdentifier, dayStart, out var status))
+                {
+                    if (status.SourceCount == 0)
+                    {
+                        _logger.LogInformation(
+                            "No source compressed rows for {LocationId} on {Date}; skipping.",
+                            location.LocationIdentifier,
+                            dayStart);
+                    }
+                    else
+                    {
+                        _logger.LogInformation(
+                            "Skipping {LocationId} on {Date}; destination contains all {SourceCount} source rows ({DestinationCount} destination rows in range).",
+                            location.LocationIdentifier,
+                            dayStart,
+                            status.SourceCount,
+                            status.DestinationCount);
+                    }
+
+                    return;
+                }
+
+                _logger.LogInformation(
+                    "Resuming {LocationId} on {Date}; destination is missing {MissingCount} of {SourceCount} source rows ({DestinationCount} destination rows in range).",
+                    location.LocationIdentifier,
+                    dayStart,
+                    status.MissingCount,
+                    status.SourceCount,
+                    status.DestinationCount);
+            }
 
             const string selectQuery = """
                 SELECT [LocationIdentifier], [DeviceId], [DataType], [Start], [End], [Data]
@@ -192,6 +256,221 @@ namespace DatabaseInstaller.Services
                 inserted,
                 location.LocationIdentifier,
                 dayStart);
+        }
+
+        private async Task<ResumePlan> BuildResumePlanAsync(
+            IReadOnlyCollection<string> locationIdentifiers,
+            string destinationConnectionString,
+            CancellationToken cancellationToken)
+        {
+            if (locationIdentifiers.Count == 0)
+            {
+                return ResumePlan.Empty;
+            }
+
+            var rangeStart = _config.Start.Date;
+            var rangeEnd = _config.End.Date.AddDays(1);
+            var sourceCounts = new Dictionary<ResumeDayKey, int>();
+            var destinationCounts = new Dictionary<ResumeDayKey, int>();
+            var missingCounts = new Dictionary<ResumeDayKey, int>();
+            var sourceKeyCount = 0;
+            var destinationKeyCount = 0;
+
+            _logger.LogInformation(
+                "Building resume plan for {LocationCount} locations from {Start} through {End}.",
+                locationIdentifiers.Count,
+                rangeStart,
+                rangeEnd.AddDays(-1));
+
+            await using var sourceConnection = new SqlConnection(_config.Source);
+            await sourceConnection.OpenAsync(cancellationToken);
+
+            await using var destinationConnection = new NpgsqlConnection(destinationConnectionString);
+            await destinationConnection.OpenAsync(cancellationToken);
+
+            foreach (var locationBatch in locationIdentifiers.Chunk(500))
+            {
+                var sourceKeys = await GetSourceKeysAsync(
+                    locationBatch,
+                    rangeStart,
+                    rangeEnd,
+                    sourceConnection,
+                    cancellationToken);
+
+                var destinationKeys = await GetDestinationKeysAsync(
+                    locationBatch,
+                    rangeStart,
+                    rangeEnd,
+                    destinationConnection,
+                    cancellationToken);
+
+                sourceKeyCount += sourceKeys.Count;
+                destinationKeyCount += destinationKeys.Count;
+
+                foreach (var key in sourceKeys)
+                {
+                    foreach (var day in GetOverlappedDays(key.Start, key.End, rangeStart, rangeEnd))
+                    {
+                        Increment(sourceCounts, new ResumeDayKey(key.LocationIdentifier, day));
+                    }
+
+                    if (destinationKeys.Contains(key))
+                    {
+                        continue;
+                    }
+
+                    foreach (var day in GetOverlappedDays(key.Start, key.End, rangeStart, rangeEnd))
+                    {
+                        Increment(missingCounts, new ResumeDayKey(key.LocationIdentifier, day));
+                    }
+                }
+
+                foreach (var key in destinationKeys)
+                {
+                    foreach (var day in GetOverlappedDays(key.Start, key.End, rangeStart, rangeEnd))
+                    {
+                        Increment(destinationCounts, new ResumeDayKey(key.LocationIdentifier, day));
+                    }
+                }
+            }
+
+            var statuses = sourceCounts.ToDictionary(
+                pair => pair.Key,
+                pair => new ResumeDayStatus(
+                    pair.Value,
+                    destinationCounts.TryGetValue(pair.Key, out var destinationCount) ? destinationCount : 0,
+                    missingCounts.TryGetValue(pair.Key, out var missingCount) ? missingCount : 0));
+
+            var completeDays = statuses.Count(pair => pair.Value.MissingCount == 0);
+            var partialDays = statuses.Count - completeDays;
+
+            _logger.LogInformation(
+                "Resume plan built from {SourceKeyCount} source keys and {DestinationKeyCount} destination keys: {CompleteDays} complete source days, {PartialDays} partial source days.",
+                sourceKeyCount,
+                destinationKeyCount,
+                completeDays,
+                partialDays);
+
+            return new ResumePlan(statuses);
+        }
+
+        private static async Task<HashSet<CompressedEventLogKey>> GetSourceKeysAsync(
+            IReadOnlyCollection<string> locationIdentifiers,
+            DateTime rangeStart,
+            DateTime rangeEnd,
+            SqlConnection sourceConnection,
+            CancellationToken cancellationToken)
+        {
+            var locationParameters = string.Join(", ", locationIdentifiers.Select((_, index) => $"@locationIdentifier{index}"));
+            var selectQuery = $"""
+                SELECT [LocationIdentifier], [DeviceId], [DataType], [Start], [End]
+                FROM [CompressedEvents]
+                WHERE [LocationIdentifier] IN ({locationParameters})
+                  AND [End] > @start
+                  AND [Start] < @end
+                """;
+
+            await using var command = new SqlCommand(selectQuery, sourceConnection);
+            AddLocationParameters(command, locationIdentifiers);
+            command.Parameters.AddWithValue("@start", rangeStart);
+            command.Parameters.AddWithValue("@end", rangeEnd);
+            command.CommandTimeout = 120;
+
+            var keys = new HashSet<CompressedEventLogKey>();
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                keys.Add(new CompressedEventLogKey(
+                    reader.GetString(0),
+                    reader.GetInt32(1),
+                    reader.GetString(2),
+                    reader.GetDateTime(3),
+                    reader.GetDateTime(4)));
+            }
+
+            return keys;
+        }
+
+        private static async Task<HashSet<CompressedEventLogKey>> GetDestinationKeysAsync(
+            IReadOnlyCollection<string> locationIdentifiers,
+            DateTime rangeStart,
+            DateTime rangeEnd,
+            NpgsqlConnection destinationConnection,
+            CancellationToken cancellationToken)
+        {
+            var locationParameters = string.Join(", ", locationIdentifiers.Select((_, index) => $"@locationIdentifier{index}"));
+            var selectQuery = $"""
+                SELECT "LocationIdentifier", "DeviceId", "DataType", "Start", "End"
+                FROM "CompressedEvents"
+                WHERE "LocationIdentifier" IN ({locationParameters})
+                  AND "End" > @start
+                  AND "Start" < @end
+                """;
+
+            await using var command = new NpgsqlCommand(selectQuery, destinationConnection);
+            AddLocationParameters(command, locationIdentifiers);
+            command.Parameters.AddWithValue("start", rangeStart);
+            command.Parameters.AddWithValue("end", rangeEnd);
+            command.CommandTimeout = 120;
+
+            var keys = new HashSet<CompressedEventLogKey>();
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                keys.Add(new CompressedEventLogKey(
+                    reader.GetString(0),
+                    reader.GetInt32(1),
+                    reader.GetString(2),
+                    reader.GetDateTime(3),
+                    reader.GetDateTime(4)));
+            }
+
+            return keys;
+        }
+
+        private static void AddLocationParameters(SqlCommand command, IReadOnlyCollection<string> locationIdentifiers)
+        {
+            var index = 0;
+            foreach (var locationIdentifier in locationIdentifiers)
+            {
+                command.Parameters.AddWithValue($"@locationIdentifier{index}", locationIdentifier);
+                index++;
+            }
+        }
+
+        private static void AddLocationParameters(NpgsqlCommand command, IReadOnlyCollection<string> locationIdentifiers)
+        {
+            var index = 0;
+            foreach (var locationIdentifier in locationIdentifiers)
+            {
+                command.Parameters.AddWithValue($"locationIdentifier{index}", locationIdentifier);
+                index++;
+            }
+        }
+
+        private static void Increment(Dictionary<ResumeDayKey, int> counts, ResumeDayKey key)
+        {
+            counts[key] = counts.TryGetValue(key, out var count) ? count + 1 : 1;
+        }
+
+        private static IEnumerable<DateTime> GetOverlappedDays(
+            DateTime start,
+            DateTime end,
+            DateTime rangeStart,
+            DateTime rangeEnd)
+        {
+            var overlapStart = start > rangeStart ? start : rangeStart;
+            var overlapEnd = end < rangeEnd ? end : rangeEnd;
+
+            if (overlapEnd <= overlapStart)
+            {
+                yield break;
+            }
+
+            for (var day = overlapStart.Date; day < overlapEnd; day = day.AddDays(1))
+            {
+                yield return day;
+            }
         }
 
         private async Task<int> InsertBatchAsync(
@@ -277,5 +556,39 @@ namespace DatabaseInstaller.Services
             DateTime Start,
             DateTime End,
             byte[]? Data);
+
+        private sealed record CompressedEventLogKey(
+            string LocationIdentifier,
+            int DeviceId,
+            string DataType,
+            DateTime Start,
+            DateTime End);
+
+        private sealed record ResumeDayKey(string LocationIdentifier, DateTime Day);
+
+        private sealed record ResumeDayStatus(int SourceCount, int DestinationCount, int MissingCount);
+
+        private sealed class ResumePlan
+        {
+            public static readonly ResumePlan Empty = new(new Dictionary<ResumeDayKey, ResumeDayStatus>());
+
+            private readonly IReadOnlyDictionary<ResumeDayKey, ResumeDayStatus> _statuses;
+
+            public ResumePlan(IReadOnlyDictionary<ResumeDayKey, ResumeDayStatus> statuses)
+            {
+                _statuses = statuses;
+            }
+
+            public bool ShouldSkip(string locationIdentifier, DateTime day, out ResumeDayStatus status)
+            {
+                if (!_statuses.TryGetValue(new ResumeDayKey(locationIdentifier, day.Date), out status!))
+                {
+                    status = new ResumeDayStatus(0, 0, 0);
+                    return true;
+                }
+
+                return status.MissingCount == 0;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add resume support for copy-sql transfer so completed location-days can be skipped safely.
- Fix Approach Speed percentile calculations for one- and two-sample speed sets.
- Add focused PlanService regression tests for small speed sample statistics.

## Included commits
- 766bce82 Add resume support for copy-sql transfer
- 4bcee5ec Fix approach speed percentile edge cases

## Verification
- dotnet test Atspm\\ApplicationTests\\ApplicationTests.csproj --no-restore --filter FullyQualifiedName~PlanServiceSpeedStatisticsTests
- dotnet build Atspm\\ReportApi\\ReportApi.csproj --no-restore
- dotnet build Atspm\\DatabaseInstaller\\DatabaseInstaller.csproj --no-restore