### PR TITLE
Use API keys for DatabaseInstaller config transfers

### DIFF
--- a/Atspm/DatabaseInstaller/Commands/TransferConfigCommand.cs
+++ b/Atspm/DatabaseInstaller/Commands/TransferConfigCommand.cs
@@ -29,14 +29,14 @@ namespace DatabaseInstaller.Commands
         public TransferConfigCommand() : base("transfer-config", "Copy configuration data from the ATSPM Config API into the target database")
         {
             AddOption(ApiBaseUrlOption);
-            AddOption(BearerTokenOption);
+            AddOption(ApiKeyOption);
             AddOption(DeleteOption);
             AddOption(UpdateLocationsOption);
             AddOption(ImportSpeedDevicesOption);
         }
 
         public Option<string> ApiBaseUrlOption { get; set; } = new("--api-base-url", () => "https://atspm.udot.utah.gov/config/", "Base URL for the source ATSPM Config API");
-        public Option<string> BearerTokenOption { get; set; } = new("--bearer-token", "Bearer token used to access the source Config API");
+        public Option<string> ApiKeyOption { get; set; } = new("--api-key", "API key used to access the source Config API");
         public Option<bool> DeleteOption { get; set; } = new("--delete", "Delete selected target records before importing");
         public Option<bool> UpdateLocationsOption { get; set; } = new("--update-locations", "Import location configuration from the source Config API");
         public Option<bool> ImportSpeedDevicesOption { get; set; } = new("--update-speed", "Import speed devices from the source Config API");
@@ -46,7 +46,7 @@ namespace DatabaseInstaller.Commands
             var binder = new ModelBinder<TransferConfigCommandConfiguration>();
 
             binder.BindMemberFromValue(b => b.ApiBaseUrl, ApiBaseUrlOption);
-            binder.BindMemberFromValue(b => b.BearerToken, BearerTokenOption);
+            binder.BindMemberFromValue(b => b.ApiKey, ApiKeyOption);
             binder.BindMemberFromValue(b => b.Delete, DeleteOption);
             binder.BindMemberFromValue(b => b.UpdateLocations, UpdateLocationsOption);
             binder.BindMemberFromValue(b => b.ImportSpeedDevices, ImportSpeedDevicesOption);
@@ -66,7 +66,7 @@ namespace DatabaseInstaller.Commands
     public class TransferConfigCommandConfiguration
     {
         public string ApiBaseUrl { get; set; }
-        public string BearerToken { get; set; }
+        public string ApiKey { get; set; }
         public bool Delete { get; set; }
         public bool UpdateLocations { get; set; }
         public bool UpdateGeneralConfiguration { get; set; }

--- a/Atspm/DatabaseInstaller/README.md
+++ b/Atspm/DatabaseInstaller/README.md
@@ -70,14 +70,14 @@ Imports configuration records from the ATSPM Config API into the target database
 ### Options
 
 - `--api-base-url`
-- `--bearer-token`
+- `--api-key`
 - `--delete`
 - `--update-locations`
 - `--update-speed`
 
 ### Notes
 
-- `--bearer-token` is required when importing configuration.
+- `--api-key` is required when importing configuration. The key is sent to the Config API in the `X-API-KEY` header.
 - With only `--update-speed`, `--delete` removes only existing speed devices before importing them again. Speed products, device configurations, locations, and other device types are preserved.
 - With `--update-locations`, `--delete` clears the existing target configuration before inserting new data.
 - `--update-locations` imports locations and related configuration data.
@@ -90,7 +90,7 @@ Imports configuration records from the ATSPM Config API into the target database
 ```bash
 dotnet run --project DatabaseInstaller -- transfer-config \
   --api-base-url "https://atspm.udot.utah.gov/config/" \
-  --bearer-token "<token>" \
+  --api-key "<key>" \
   --update-locations true
 ```
 

--- a/Atspm/DatabaseInstaller/Services/TransferConfigCommandHostedService.cs
+++ b/Atspm/DatabaseInstaller/Services/TransferConfigCommandHostedService.cs
@@ -165,9 +165,9 @@ public class TransferConfigCommandHostedService : IHostedService
 
     private async Task<SourceConfigData> LoadSourceConfigDataAsync(CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(_config.BearerToken))
+        if (string.IsNullOrWhiteSpace(_config.ApiKey))
         {
-            throw new InvalidOperationException("A bearer token is required when transferring configuration from the Config API.");
+            throw new InvalidOperationException("An API key is required when transferring configuration from the Config API.");
         }
 
         using var client = CreateApiClient();
@@ -318,7 +318,9 @@ public class TransferConfigCommandHostedService : IHostedService
             .ToHashSet();
 
         return devices
-            .Where(d => d.DeviceConfigurationId.HasValue && speedConfigurationIds.Contains(d.DeviceConfigurationId.Value))
+            .Where(d =>
+                d.DeviceType == DeviceTypes.SpeedSensor ||
+                (d.DeviceConfigurationId.HasValue && speedConfigurationIds.Contains(d.DeviceConfigurationId.Value)))
             .ToList();
     }
 
@@ -328,7 +330,7 @@ public class TransferConfigCommandHostedService : IHostedService
         {
             BaseAddress = BuildBaseUri(_config.ApiBaseUrl)
         };
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _config.BearerToken);
+        client.DefaultRequestHeaders.Add("X-API-KEY", _config.ApiKey);
         client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         return client;
     }

--- a/Atspm/DatabaseInstallerTests/TransferConfigUpdateSpeedTests.cs
+++ b/Atspm/DatabaseInstallerTests/TransferConfigUpdateSpeedTests.cs
@@ -38,7 +38,17 @@ public class TransferConfigUpdateSpeedTests
     }
 
     [Fact]
-    public async Task StartAsync_UpdateSpeedWithoutBearerToken_Throws()
+    public void ApiKeyOption_ParsesValue()
+    {
+        var command = new TransferConfigCommand();
+
+        var parseResult = command.Parse(new[] { "--api-key", "test-api-key" });
+
+        Assert.Equal("test-api-key", parseResult.GetValueForOption(command.ApiKeyOption));
+    }
+
+    [Fact]
+    public async Task StartAsync_UpdateSpeedWithoutApiKey_Throws()
     {
         var service = CreateHostedService(new TransferConfigCommandConfiguration
         {
@@ -50,12 +60,12 @@ public class TransferConfigUpdateSpeedTests
             () => service.StartAsync(CancellationToken.None));
 
         Assert.Equal(
-            "A bearer token is required when transferring configuration from the Config API.",
+            "An API key is required when transferring configuration from the Config API.",
             exception.Message);
     }
 
     [Fact]
-    public async Task StartAsync_DeleteSpeedWithoutBearerToken_DoesNotDeleteDevices()
+    public async Task StartAsync_DeleteSpeedWithoutApiKey_DoesNotDeleteDevices()
     {
         var deviceRepository = new Mock<IDeviceRepository>();
         var service = CreateHostedService(
@@ -76,7 +86,7 @@ public class TransferConfigUpdateSpeedTests
     }
 
     [Fact]
-    public async Task StartAsync_WithoutUpdateFlags_DoesNotRequireBearerToken()
+    public async Task StartAsync_WithoutUpdateFlags_DoesNotRequireApiKey()
     {
         var deviceRepository = new Mock<IDeviceRepository>();
         var service = CreateHostedService(
@@ -89,7 +99,27 @@ public class TransferConfigUpdateSpeedTests
     }
 
     [Fact]
-    public void IdentifySpeedDevices_IncludesSpeedConfigurationAndWavetronixProduct()
+    public void CreateApiClient_UsesApiKeyHeaderWithoutBearerAuthorization()
+    {
+        var service = CreateHostedService(new TransferConfigCommandConfiguration
+        {
+            ApiBaseUrl = "https://example.test/",
+            ApiKey = "test-api-key"
+        });
+        var method = typeof(TransferConfigCommandHostedService).GetMethod(
+            "CreateApiClient",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        using var client = Assert.IsType<HttpClient>(method.Invoke(service, null));
+
+        Assert.Null(client.DefaultRequestHeaders.Authorization);
+        Assert.Equal(
+            "test-api-key",
+            Assert.Single(client.DefaultRequestHeaders.GetValues("X-API-KEY")));
+    }
+
+    [Fact]
+    public void IdentifySpeedDevices_IncludesSpeedDeviceTypeConfigurationAndWavetronixProduct()
     {
         var products = new List<Product>
         {
@@ -107,7 +137,8 @@ public class TransferConfigUpdateSpeedTests
             new() { Id = 1, DeviceConfigurationId = 100 },
             new() { Id = 2, DeviceConfigurationId = 101 },
             new() { Id = 3, DeviceConfigurationId = 102 },
-            new() { Id = 4, DeviceConfigurationId = null }
+            new() { Id = 4, DeviceConfigurationId = null },
+            new() { Id = 5, DeviceType = DeviceTypes.SpeedSensor, DeviceConfigurationId = 102 }
         };
 
         var method = typeof(TransferConfigCommandHostedService).GetMethod(
@@ -117,7 +148,7 @@ public class TransferConfigUpdateSpeedTests
         var result = Assert.IsType<List<Device>>(
             method.Invoke(null, new object[] { devices, configurations, products }));
 
-        Assert.Equal(new[] { 1, 2 }, result.Select(device => device.Id));
+        Assert.Equal(new[] { 1, 2, 5 }, result.Select(device => device.Id));
     }
 
     [Fact]

--- a/Atspm/InfrastructureTests/DatabaseInstallerTests/TransferConfigCommandTests.cs
+++ b/Atspm/InfrastructureTests/DatabaseInstallerTests/TransferConfigCommandTests.cs
@@ -73,7 +73,7 @@ public class TransferConfigCommandTests
             new[]
             {
                 "--api-base-url",
-                "--bearer-token",
+                "--api-key",
                 "--delete",
                 "--update-locations",
                 "--update-speed"


### PR DESCRIPTION
## Summary
- replace the Database Installer `--bearer-token` option with `--api-key`
- authenticate Config API requests through the `X-API-KEY` header
- recognize devices whose type is `SpeedSensor` while retaining the existing speed-configuration and Wavetronix matching rules
- update command documentation and regression coverage

## Validation
- `dotnet test DatabaseInstallerTests/DatabaseInstallerTests.csproj`: 16 passed
- focused Database Installer tests in `InfrastructureTests`: 5 passed
- live non-delete test transfer: identified and imported one `SpeedSensor`; target verification found one speed device and zero duplicate identifier/location groups