### PR TITLE
Revert "Add valid SQL Server type so migration works"

### DIFF
--- a/Atspm/SqlDatabaseProvider/Migrations/Config/20260318134420_5_1_4.cs
+++ b/Atspm/SqlDatabaseProvider/Migrations/Config/20260318134420_5_1_4.cs
@@ -37,7 +37,7 @@ namespace Utah.Udot.ATSPM.SqlDatabaseProvider.Migrations
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
                     ApiName = table.Column<string>(type: "varchar(32)", unicode: false, maxLength: 32, nullable: true),
-                    Timestamp = table.Column<DateTime>(type: "datetimeoffset", nullable: false),
+                    Timestamp = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                     TraceId = table.Column<string>(type: "varchar(100)", unicode: false, maxLength: 100, nullable: true),
                     ConnectionId = table.Column<string>(type: "varchar(100)", unicode: false, maxLength: 100, nullable: true),
                     RemoteIp = table.Column<string>(type: "varchar(45)", unicode: false, maxLength: 45, nullable: true),


### PR DESCRIPTION
Reverts utahudot/udot-atspm#343
I want this to be tested before i fully commit it.
It's possible that the migration after this one might not run because it will try to overwrite a value that is a different type